### PR TITLE
feat: add repo for dcp

### DIFF
--- a/otterdog/eclipse-dataspace-dcp.jsonnet
+++ b/otterdog/eclipse-dataspace-dcp.jsonnet
@@ -1,4 +1,4 @@
-local orgs = import 'otterdog-defaults.libsonnet';
+local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 orgs.newOrg('eclipse-dataspace-dcp') {
   settings+: {

--- a/otterdog/eclipse-dataspace-dcp.jsonnet
+++ b/otterdog/eclipse-dataspace-dcp.jsonnet
@@ -12,7 +12,7 @@ orgs.newOrg('eclipse-dataspace-dcp') {
   },
 _repositories+:: [
   orgs.newRepo('decentralized-claims-protocol') {
-    allow_rebase_merge: false,
+    allow_rebase_merge: true,
     allow_update_branch: false,
     delete_branch_on_merge: false,
     description: "Specification for the Decentralized Claims Protocol (DCP)",

--- a/otterdog/eclipse-dataspace-dcp.jsonnet
+++ b/otterdog/eclipse-dataspace-dcp.jsonnet
@@ -1,4 +1,4 @@
-local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
+local orgs = import 'otterdog-defaults.libsonnet';
 
 orgs.newOrg('eclipse-dataspace-dcp') {
   settings+: {
@@ -10,4 +10,19 @@ orgs.newOrg('eclipse-dataspace-dcp') {
       actions_can_approve_pull_request_reviews: false,
     },
   },
+_repositories+:: [
+  orgs.newRepo('decentralized-claims-protocol') {
+    allow_rebase_merge: false,
+    allow_update_branch: false,
+    delete_branch_on_merge: false,
+    description: "Specification for the Decentralized Claims Protocol (DCP)",
+    has_discussions: true,
+    has_wiki: false,
+    squash_merge_commit_title: "PR_TITLE",
+    web_commit_signoff_required: false,
+    workflows+: {
+      default_workflow_permissions: "write",
+    },
+  },
+  ]
 }


### PR DESCRIPTION
tested with [otterdog playground](https://eclipse-dataspace-dcp.github.io/.eclipsefdn/playground/). Points to discuss:

- [x] Decision Proposal: Do not separate Base Protocol, Verifiable Presentation Protocol, Credential Issuance Protocols in separate repos. It'd introduce the need for cross-references - especially for the common base, terms, references etc.
- [x] Any settings we need different from the get-go?