### PR TITLE
fix: change pages deployment branch

### DIFF
--- a/otterdog/eclipse-dataspace-dcp.jsonnet
+++ b/otterdog/eclipse-dataspace-dcp.jsonnet
@@ -21,10 +21,13 @@ orgs.newOrg('eclipse-dataspace-dcp') {
       has_discussions: true,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
+      workflows+: {
+              default_workflow_permissions: "write",
+      },
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "gh-pages"
+            "main"
           ],
           deployment_branch_policy: "selected",
         },

--- a/otterdog/eclipse-dataspace-dcp.jsonnet
+++ b/otterdog/eclipse-dataspace-dcp.jsonnet
@@ -21,9 +21,6 @@ orgs.newOrg('eclipse-dataspace-dcp') {
       has_discussions: true,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
-      workflows+: {
-              default_workflow_permissions: "write",
-      },
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [


### PR DESCRIPTION
There's currently an issue when deploying github pages via [`actions/deploy-pages`](https://github.com/actions/deploy-pages) after push to the main branch. The result is the workflow failing without logs like here [1]. This PR gives deployment rights to "main" (which is in line with the workflow) and grants write privileges.


[1] https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/actions/runs/10617083432/job/29429061881