### PR TITLE
chore: add best practices document

### DIFF
--- a/otterdog/eclipse-dataspace-dcp.jsonnet
+++ b/otterdog/eclipse-dataspace-dcp.jsonnet
@@ -31,6 +31,26 @@ orgs.newOrg('technology.dataspace-dcp', 'eclipse-dataspace-dcp') {
         },
       ],
     },
+    orgs.newRepo('best-practices') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "This repository contains non-normative companion documents for adopters of the Eclipse Decentralized Claims Protocol (DCP)",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      has_discussions: true,
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+    },
   ],
 } + {
   # snippet added due to 'https://github.com/EclipseFdn/otterdog-configs/blob/main/blueprints/add-dot-github-repo.yml'


### PR DESCRIPTION
This PR adds a best-practices document as decided in the committer meeting.

closes https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol/issues/192